### PR TITLE
Remove download_url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
     name='Markdown',
     version=__version__,
     url='https://Python-Markdown.github.io/',
-    download_url='http://pypi.python.org/packages/source/M/Markdown/Markdown-%s-py2.py3-none-any.whl' % __version__,
     project_urls={
         'Documentation': 'https://Python-Markdown.github.io/',
         'GitHub Project': 'https://github.com/Python-Markdown/markdown',


### PR DESCRIPTION
This is an old, outdated key which is simply moved into `project_urls`. As it offers to value, it is being removed.
Fixes #1163.